### PR TITLE
changed package type from "project" to "library"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name"       : "gpolguere/path-to-regexp-php",
-	"type"       : "project",
+	"type"       : "library",
 	"homepage"   : "https://github.com/gpolguere/path-to-regexp-php",
 	"description": "PHP port of https://github.com/component/path-to-regexp",
 	"authors"    : [


### PR DESCRIPTION
Shouldn't it be a library instead ? See: https://getcomposer.org/doc/04-schema.md#type
Because of this I'm unable to use your library in my project, as the following command fails :
`composer require gpolguere/path-to-regexp-php`